### PR TITLE
CI: Limit GitHub Pages deploy to public folderCI: Limit GitHub Pages deploy to public folderCI: Limit GitHub Pages …

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-﻿name: Deploy static site to Pages
+name: Deploy static site to Pages
 on:
   push: { branches: [main] }
   workflow_dispatch:
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/upload-pages-artifact@v3
-        with: { path: "." }
+        with: { path: "./public" }
   deploy:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR limits the GitHub Pages deploy scope to the ./public folder, preventing accidental exposure of non-site source files or sensitive assets by restricting what gets published. This is a safer default for static site repositories and aligns with best practices for GitHub Actions deployments.…deploy to public folderUpdate pages.yml

Change upload-pages-artifact path from '.' to './public' to limit deployment scope to only static site assets, preventing accidental exposure of source files and sensitive assets.